### PR TITLE
Update: Use serenity next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.8",
  "once_cell",
  "version_check",
 ]
@@ -26,7 +26,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.9",
+ "getrandom 0.2.8",
  "once_cell",
  "version_check",
 ]
@@ -79,22 +79,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.13",
-]
-
-[[package]]
-name = "async-tungstenite"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b71b31561643aa8e7df3effe284fa83ab1a840e52294c5f4bd7bfd8b2becbb"
-dependencies = [
- "futures-io",
- "futures-util",
- "log",
- "pin-project-lite",
- "tokio",
- "tokio-rustls",
- "tungstenite",
- "webpki-roots",
 ]
 
 [[package]]
@@ -294,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -433,6 +417,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.12.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+ "serde",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,13 +557,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -794,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1003,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1063,13 +1061,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1080,14 +1078,14 @@ checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1122,9 +1120,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1327,9 +1325,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.50"
+version = "0.10.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+checksum = "4d2f106ab837a24e03672c59b1239669a0596406ff657c3c0835b6b7f0f35a33"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1359,23 +1357,14 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.85"
+version = "0.9.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+checksum = "3a20eace9dc2d82904039cb76dcf50fb1a0bba071cfd1629720b5d6f1ddba0fa"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "ordered-float"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1561,9 +1550,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "1d0dd4be24fcdcfeaa12a432d588dc59bbad6cad3510c67e74a2b6b2fc950564"
 dependencies = [
  "unicode-ident",
 ]
@@ -1668,7 +1657,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -1713,7 +1702,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.8",
  "redox_syscall 0.2.16",
  "thiserror",
 ]
@@ -1826,16 +1815,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "d097081ed288dfe45699b72f5b5d648e5f15d64d900c7080273baa20c16a6849"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2019,16 +2008,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331bb8c3bf9b92457ab7abecf07078c13f7d270ba490103e84e8b014490cd0b0"
+checksum = "85456ffac572dc8826334164f2fb6fb40a7c766aebe195a2a21ee69ee2885ecf"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -2089,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.3.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859011bddcc11f289f07f467cc1fe01c7a941daa4d8f6c40d4d1c92eb6d9319c"
+checksum = "7cbcd6104f8a4ab6af7f6be2a0da6be86b9de3c401f6e86bb856ab2af739232f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2102,26 +2081,25 @@ dependencies = [
 [[package]]
 name = "serenity"
 version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fd5e7b5858ad96e99d440138f34f5b98e1b959ebcd3a1036203b30e78eb788"
+source = "git+https://github.com/serenity-rs/serenity?rev=c628b15228ae1044d2a3e785a52b9cd8e8f52f21#c628b15228ae1044d2a3e785a52b9cd8e8f52f21"
 dependencies = [
  "async-trait",
- "async-tungstenite",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bitflags",
  "bytes",
- "cfg-if",
+ "dashmap",
  "flate2",
  "futures",
- "mime",
+ "fxhash",
  "mime_guess",
+ "parking_lot",
  "percent-encoding",
  "reqwest",
  "serde",
- "serde-value",
  "serde_json",
  "time 0.3.20",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "typemap_rev",
  "url",
@@ -2138,10 +2116,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
+name = "sha1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2499,6 +2477,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,9 +2596,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -2614,7 +2608,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustls",
- "sha-1",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",
@@ -2623,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "typemap_rev"
-version = "0.1.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5b74f0a24b5454580a79abb6994393b09adf0ab8070f15827cb666255de155"
+checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
 
 [[package]]
 name = "typenum"
@@ -2908,11 +2902,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.48.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.42.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ inherits = "release"
 
 [dependencies]
 tokio = { version = "1.27.0", features = ["macros", "rt-multi-thread"] }
-serenity = { default-features = false, features = ["client", "gateway", "model", "rustls_backend"], version = "0.11"}
+serenity = { default-features = false, features = ["client", "gateway", "model", "rustls_backend", "cache"], git = "https://github.com/serenity-rs/serenity", rev = "c628b15228ae1044d2a3e785a52b9cd8e8f52f21"}
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.7.3"
 log = "0.4.17"
@@ -28,7 +28,7 @@ lazy_static = "1.4.0"
 async-trait = "0.1.68"
 rand = "0.8.5"
 serde_json = "1.0.95"
-reqwest = "0.11.16"
+reqwest = { version = "0.11.16", features = ["json"]}
 structstruck = "0.4.0"
 urlencoding = "2.1.2"
 truncrate = "0.1.3"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If your desired platform isn't seen below, please [open an issue][issues].
 <details>
 <summary>Linux</summary>
 
-> The recommended way to install Tara is by way of a package manager.
+> The recommended way to install Tara is by way of a package manager, however, **[crates.io]** [may be outdated](https://github.com/El-Wumbus/Tara/pull/3) and Tara should be installed from [GitHub releases][github-release].
 > If using `cargo install`, some dependencies won't automatically be installed. You'll need to install `sqlite3` previous to running the instructions.
 > On Debian and Ubuntu systems the required package is `libsqlite3-dev`, on Arch and related systems it's `sqlite`.
 >
@@ -38,7 +38,7 @@ If your desired platform isn't seen below, please [open an issue][issues].
 <details>
 <summary>macOS</summary>
 
-> The recommended way to install Tara is by way of a package manager.
+> The recommended way to install Tara is by way of a package manager, however, **[crates.io]** [may be outdated](https://github.com/El-Wumbus/Tara/pull/3) and Tara should be installed from [GitHub releases][github-release].
 > | Repository      | Instructions                 |
 > | --------------- | ---------------------------- |
 > | **[crates.io]** | `cargo install tara --locked`|
@@ -52,7 +52,7 @@ Tara has an interactive setup subcommand, `tara config init`.
 
 ```sh
 $ tara config init --help
-tara-config-init 0.2.0
+tara-config-init 0.3.1
 Create configuration files with a user-provided configuration
 
 USAGE:
@@ -139,7 +139,7 @@ To start Tara, use the `tara daemon` command. If no errors or warnings occur, Ta
 
 ```sh
 $ tara daemon --help
-tara-daemon 0.2.0
+tara-daemon  0.3.1
 Start Tara
 
 USAGE:

--- a/src/commands/search/ddg.rs
+++ b/src/commands/search/ddg.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use lazy_static::lazy_static;
 use rustrict::Type;
 use scraper::{Html, Selector};
 
@@ -34,15 +33,6 @@ impl std::fmt::Display for SearchResult {
     }
 }
 
-// Use lazy statics so we only pay for this initialization once. Also, rustrict doesn't
-// implement constant bitwise or, so we can't compute that at compile time.
-lazy_static! {
-    pub static ref SEXUAL_OR_PROFANE: rustrict::Type = Type::SEXUAL | Type::PROFANE;
-    pub static ref RESULT_SELECTOR: Selector = Selector::parse(".web-result").unwrap();
-    pub static ref RESULT_TITLE_SELECTOR: Selector = Selector::parse(".result__a").unwrap();
-    pub static ref RESULT_SNIPPET_SELECTOR: Selector = Selector::parse(".result__snippet").unwrap();
-}
-
 pub async fn scrape(search_term: &str, result_count: usize) -> Result<(Vec<SearchResult>, String)> {
     use rustrict::Censor;
 
@@ -60,34 +50,36 @@ pub async fn scrape(search_term: &str, result_count: usize) -> Result<(Vec<Searc
     let client = reqwest::Client::new();
     let resp = client.get(&url).send().await.map_err(Error::HttpRequest)?;
     let document = Html::parse_document(&resp.text().await.map_err(Error::HttpRequest)?);
-
+    let result_selector = Selector::parse(".web-result").unwrap();
+    let result_title_selector = Selector::parse(".result__a").unwrap();
+    let result_snippet_selector = Selector::parse(".result__snippet").unwrap();
 
     // We make a hashset of the results' titles. This is done to more efficiantly
     // ensure unique titles
     let mut results_hash = HashSet::new();
 
     let results = document
-        .select(&RESULT_SELECTOR)
+        .select(&result_selector)
         .filter_map(|result| {
             // Get the title
-            let result_title = result.select(&RESULT_TITLE_SELECTOR).next().unwrap();
+            let result_title = result.select(&result_title_selector).next().unwrap();
             let title = Censor::from_str(&result_title.text().collect::<String>())
                 .with_censor_replacement('#')
                 .censor_and_analyze();
 
             // If we've seen this title before, or the title is sexual or profane, we skip
             // this result.
-            if results_hash.contains(&title.0) || title.1.is(*SEXUAL_OR_PROFANE) {
+            if results_hash.contains(&title.0) || title.1.is(Type::SEXUAL | Type::PROFANE) {
                 return None;
             }
 
-            let result_snippet = result.select(&RESULT_SNIPPET_SELECTOR).next().unwrap();
+            let result_snippet = result.select(&result_snippet_selector).next().unwrap();
             let snippet = Censor::from_str(&result_snippet.text().collect::<String>())
                 .with_censor_replacement('#')
                 .censor_and_analyze();
 
             // If the snippet is sexual or profane, we skip this result
-            if snippet.1.is(*SEXUAL_OR_PROFANE) {
+            if snippet.1.is(Type::SEXUAL | Type::PROFANE) {
                 return None;
             }
 

--- a/src/commands/settings/view.rs
+++ b/src/commands/settings/view.rs
@@ -1,10 +1,10 @@
-use serenity::model::prelude::interaction::application_command::ApplicationCommandInteraction;
+use serenity::all::CommandInteraction;
 
 use crate::Result;
 
 
 pub fn maximum_content_output_chars(
-    command: &ApplicationCommandInteraction,
+    command: &CommandInteraction,
     databases: &crate::database::Databases,
 ) -> Result<String> {
     let max = super::super::core::get_max_content_len(command, databases)?;

--- a/src/database.rs
+++ b/src/database.rs
@@ -47,7 +47,7 @@ impl Databases {
         let mut statement = connection
             .prepare(&format!(
                 "SELECT EXISTS (SELECT 1 FROM {table} WHERE GuildID={})",
-                id.as_u64()
+                u64::from(*id.as_inner())
             ))
             .map_err(crate::Error::from)?;
         let exists = statement.query_row([], |row| {
@@ -71,11 +71,10 @@ impl Databases {
                 "INSERT INTO guilds (GuildID, max_content_chars, assignable_roles)
                     VALUES (?1, ?2, ?3)",
                 params![
-                    guild_id.as_u64(),
+                    u64::from(*guild_id.as_inner()),
                     crate::commands::wiki::Wiki::DEFAULT_MAX_WIKI_LEN,
                     {
-                        let mut assignable_roles: HashSet<RoleId> = HashSet::new();
-                        assignable_roles.insert(RoleId(0));
+                        let assignable_roles: HashSet<RoleId> = HashSet::new();
                         bincode::serialize(&assignable_roles).unwrap()
                     }
                 ],


### PR DESCRIPTION
Port existing codebase over to serenity's *next* branch (rev=`c628b15228ae1044d2a3e785a52b9cd8e8f52f21`). This comes with benefits, like being able to use [songbird's *next*](https://github.com/serenity-rs/songbird/tree/next), but also downsides. [Crates.io](https://crates.io) disallows using git repositories as a source for crates. This means the [Tara crate](https://crates.io/crates/tara) will be outdated until *next* becomes *current*.